### PR TITLE
feat(task-10): add composite and decorator pattern examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - [x] Умная розетка по TCP [link](./homework%20tasks/7%20-%20Умная%20розетка%20по%20TCP.md) [code](https://github.com/Pi1at/rust_education_homework/tree/task-7/smarthome)
 - [x] Термометр по UDP [link](./homework%20tasks/8%20-%20Термометр%20по%20UDP.md) [code](https://github.com/Pi1at/rust_education_homework/tree/task-8/smarthome)
 - [x] Асинхронное сетевое взаимодействие [link](./homework%20tasks/9%20-%20Асинхронное%20сетевое%20взаимодействие.md) [code](https://github.com/Pi1at/rust_education_homework/tree/task-9/smarthome)
-- [ ] Паттерны проектирования [link](./homework%20tasks/10%20-%20Паттерны%20проектирования.md)
+- [x] Паттерны проектирования [link](./homework%20tasks/10%20-%20Паттерны%20проектирования.md) [code](https://github.com/Pi1at/rust_education_homework/tree/task-10/patterns)
 - [ ] Крейт thiserror [link](./homework%20tasks/11%20-%20Крейт%20thiserror.md)
 - [ ] Rust паттерны [link](./homework%20tasks/12%20-%20Rust%20паттерны.md)
 - [ ] Веб-сервер "умного дома" [link](./homework%20tasks/13%20-%20Веб-сервер%20"умного%20дома".md)

--- a/patterns/Cargo.toml
+++ b/patterns/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+edition = "2021"
+name    = "patterns"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rand = "0.8.5"

--- a/patterns/examples/composite.rs
+++ b/patterns/examples/composite.rs
@@ -1,0 +1,66 @@
+// The composite pattern describes a group of objects that are treated the same way as a single instance
+// of the same type of object. The intent of a composite is to "compose" objects into tree structures
+// to represent part-whole hierarchies. Implementing the composite pattern lets clients treat
+// individual objects and compositions uniformly
+
+use patterns::composite::*;
+use rand::{thread_rng, Rng};
+fn static_composite() {
+    use impl_static::*;
+
+    struct Pallet<T> {
+        parcels: Vec<T>,
+    }
+
+    fn create_parcel(n: usize) -> Parcel<Commodity> {
+        let mut rng = thread_rng();
+        let mut p = Vec::with_capacity(n);
+        (0..n).for_each(|_| {
+            let price: f32 = rng.gen_range(0.0..4242.0);
+            p.push(Commodity { price });
+        });
+        Parcel { children: p }
+    }
+
+    impl<T: PriceReporing> PriceReporing for Pallet<T> {
+        fn report_price(&self, indent: u8) {
+            println!("{:i$} pallet with:", "", i = indent as usize);
+            for p in &self.parcels {
+                p.report_price(indent + 2)
+            }
+        }
+    }
+    let pallet = Pallet {
+        parcels: vec![create_parcel(3), create_parcel(1), create_parcel(2)],
+    };
+    pallet.report_price(0)
+}
+
+fn dynamic_composite() {
+    use impl_dynamic::*;
+    fn create_parcel(n: usize) -> Box<dyn PriceReporing> {
+        let mut rng = thread_rng();
+        let mut p = Vec::<Box<dyn PriceReporing>>::with_capacity(n);
+        (0..n).for_each(|_| {
+            if rng.gen_ratio(5, 6) {
+                let price: f32 = rng.gen_range(0.0..4242.0);
+                p.push(Box::new(Commodity { price }));
+            } else {
+                p.push(create_parcel(n / 3))
+            }
+        });
+        Box::new(Parcel { children: p })
+    }
+    let pallet = Parcel {
+        children: vec![create_parcel(5), create_parcel(12)],
+    };
+    pallet.report_price(0);
+}
+
+fn main() {
+    println!("Comosite pattern example");
+    println!("[static]");
+    static_composite();
+    println!("[dynamic]");
+    dynamic_composite();
+}

--- a/patterns/examples/decorator.rs
+++ b/patterns/examples/decorator.rs
@@ -1,0 +1,22 @@
+use patterns::decorator::Circle;
+use patterns::decorator::*;
+
+fn static_decorator() {
+    let decorated_circle = impl_static::Decorator::new(Square { a: 33.0 });
+    decorated_circle.draw();
+}
+
+fn dynamic_decorator() {
+    let circle = Circle { r: 42.0 };
+    let decorated_circle = impl_dynamic::Decorator {
+        shape: Box::new(circle),
+        title: "Red".into(),
+    };
+    decorated_circle.draw();
+}
+
+fn main() {
+    println!("Decorator pattern example");
+    static_decorator();
+    dynamic_decorator();
+}

--- a/patterns/src/composite/mod.rs
+++ b/patterns/src/composite/mod.rs
@@ -1,0 +1,51 @@
+pub trait PriceReporing {
+    fn report_price(&self, indent: u8);
+}
+
+pub struct Commodity {
+    pub price: f32,
+}
+
+impl PriceReporing for Commodity {
+    fn report_price(&self, indent: u8) {
+        println!(
+            "{:i$} commodity with price: {:.2}",
+            "",
+            self.price,
+            i = indent as usize
+        );
+    }
+}
+
+pub mod impl_dynamic {
+    use super::PriceReporing;
+
+    pub struct Parcel {
+        pub children: Vec<Box<dyn PriceReporing>>,
+    }
+
+    impl PriceReporing for Parcel {
+        fn report_price(&self, indent: u8) {
+            println!("{:i$} parcel contains:", "", i = indent as usize);
+            for child in &self.children {
+                child.report_price(indent + 2);
+            }
+        }
+    }
+}
+pub mod impl_static {
+    use super::PriceReporing;
+
+    pub struct Parcel<T: PriceReporing> {
+        pub children: Vec<T>,
+    }
+
+    impl<T: PriceReporing> PriceReporing for Parcel<T> {
+        fn report_price(&self, indent: u8) {
+            println!("{:i$} parcel contains:", "", i = indent as usize);
+            for child in &self.children {
+                child.report_price(indent + 2);
+            }
+        }
+    }
+}

--- a/patterns/src/decorator/mod.rs
+++ b/patterns/src/decorator/mod.rs
@@ -1,0 +1,74 @@
+// In object-oriented programming, the decorator pattern is a design pattern
+// that allows behavior to be added to an individual object, dynamically,
+// without affecting the behavior of other instances of the same class.
+// The decorator pattern is often useful for adhering to the Single Responsibility Principle,
+// as it allows functionality to be divided between classes with unique areas of concern
+// as well as to the Open-Closed Principle, by allowing the functionality of a class to be extended without being modified.
+// Decorator use can be more efficient than subclassing, because an object's behavior can be augmented without defining an entirely new object.
+
+pub struct Circle {
+    pub r: f32,
+}
+
+pub trait Shape {
+    fn draw(&self);
+}
+
+impl Shape for Circle {
+    fn draw(&self) {
+        println!("Drawing Circle with radius {}", self.r);
+    }
+}
+pub struct Square {
+    pub a: f32,
+}
+
+impl Shape for Square {
+    fn draw(&self) {
+        println!("Drawing Square with side {}", self.a);
+    }
+}
+
+pub mod impl_dynamic {
+    use super::Shape;
+
+    pub struct Decorator {
+        pub shape: Box<dyn Shape>,
+        pub title: String,
+    }
+
+    impl Shape for Decorator {
+        fn draw(&self) {
+            self.shape.draw();
+            println!("[dynamic]: adding title {}", self.title);
+        }
+    }
+}
+
+pub mod impl_static {
+    use super::{Circle, Shape};
+
+    pub struct Decorator<T: Shape> {
+        pub shape: T,
+        inner_shape: Circle,
+    }
+
+    impl<T: Shape> Decorator<T> {
+        pub fn new(x: T) -> Self {
+            Self {
+                shape: x,
+                inner_shape: Circle { r: 10.0 },
+            }
+        }
+    }
+
+    impl<T: Shape> Shape for Decorator<T> {
+        fn draw(&self) {
+            self.shape.draw();
+            println!(
+                "[static]: adding circle, with radius {}",
+                self.inner_shape.r
+            );
+        }
+    }
+}

--- a/patterns/src/lib.rs
+++ b/patterns/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod composite;
+pub mod decorator;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced examples and implementations of the Composite and Decorator design patterns in Rust, enhancing the understanding and application of these patterns.
	- Added a new section in the documentation marking the task "Паттерны проектирования" as completed and providing a code link for reference.
- **Documentation**
	- Updated README.md to reflect the completion of a task and added links to new code examples for the Composite and Decorator patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->